### PR TITLE
comply with pep-0353 requirements

### DIFF
--- a/scryptmodule.c
+++ b/scryptmodule.c
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#define PY_SSIZE_T_CLEAN 1
 #include <Python.h>
 
 //#include "scrypt.h"
@@ -38,10 +39,10 @@ static PyObject *scrypt_getpowhash(PyObject *self, PyObject *args)
 
 static PyObject *scrypt_getpowhash(PyObject *self, PyObject *args, PyObject* kwargs) {
     char *input;
-    int      inputlen;
+    Py_ssize_t inputlen;
 
     char *outbuf;
-    size_t   outbuflen;
+    Py_ssize_t outbuflen;
 
     static char *g2_kwlist[] = {"input", NULL};
 


### PR DESCRIPTION
On Ubuntu 22.04 Jammy, the previous archive hosted by langerhans would not install on account of Python 3.10.5's requirement to define the PY_SSIZE_T_CLEAN macro prior to including <Python.h> for all # variants of formats (s#, y#, etc.) found in scryptmodule.c. This PR fixes that. 

References:
https://bugs.launchpad.net/ubuntu/+source/python-systemd/+bug/1963582
https://github.com/python/cpython/commit/569ca81adf0be92be8752f6cc6492117f9ef3c0b
https://peps.python.org/pep-0353/
https://github.com/dogecoin/dogecoin/issues/2656