### PR TITLE
build wheels using Github actions, add test

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,65 @@
+name: Build and upload to PyPI
+
+# Build on every branch push, tag push, and pull request change:
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.archs }} for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: windows-2019
+            archs: auto
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Build wheels
+        uses: joerick/cibuildwheel@v2.3.1
+        env:
+          CIBW_TEST_COMMAND: "python {package}/test.py"
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+
+      - name: Build sdist
+        run: python setup.py sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/test.py
+++ b/test.py
@@ -1,0 +1,7 @@
+import ltc_scrypt
+
+teststart = '000000203a297b4b7685170d7644b43e5a6056234cc2414edde454a87580e1967d14c1078c13ea916117b0608732f3f65c2e03b81322efc0a62bcee77d8a9371261970a58a5a715da80e031b02560ad8'
+
+testbin = bytes.fromhex(teststart)
+hash_bin_scrypt = ltc_scrypt.getPoWHash(testbin)
+print("ltc_scrypt", hash_bin_scrypt.hex())


### PR DESCRIPTION
Part 2 of breaking up https://github.com/dogecoin/ltc-scrypt/pull/1

This is set up to build wheels on push/pull and deploy to PyPI on tags starting with `v` using `pypi_password` in secrets 

```
12 wheels produced in 13 minutes:
  ltc_scrypt-1.0-cp310-cp310-win32.whl
  ltc_scrypt-1.0-cp310-cp310-win_amd64.whl
  ltc_scrypt-1.0-cp36-cp36m-win32.whl
  ltc_scrypt-1.0-cp36-cp36m-win_amd64.whl
  ltc_scrypt-1.0-cp37-cp37m-win32.whl
  ltc_scrypt-1.0-cp37-cp37m-win_amd64.whl
  ltc_scrypt-1.0-cp38-cp38-win32.whl
  ltc_scrypt-1.0-cp38-cp38-win_amd64.whl
  ltc_scrypt-1.0-cp39-cp39-win32.whl
  ltc_scrypt-1.0-cp39-cp39-win_amd64.whl
  ltc_scrypt-1.0-pp37-pypy37_pp73-win_amd64.whl
  ltc_scrypt-1.0-pp38-pypy38_pp73-win_amd64.whl
```

```
python test.py 
('ltc_scrypt', '53232d90adebc88ab0855434cfaf6822fce47c62b2bdd7e8d84f667868a1ee40')
```