### PR TITLE
qa: create a ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: Continuous Integration
+
+on:
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        name:
+          - bionic-py36-gcc7
+          - focal-py38-gcc9
+          - jammy-py310-gcc11
+          - jammy-py310-clang14
+        include:
+          - name: bionic-py36-gcc7
+            host: ubuntu-18.04
+            packages: python3 python3-distutils python3.6-dev gcc-7-multilib
+          - name: focal-py38-gcc9
+            host: ubuntu-20.04
+            packages: python3 python3-distutils python3.8-dev gcc-9-multilib
+          - name: jammy-py310-gcc11
+            host: ubuntu-22.04
+            packages: python3 python3-distutils python3.10-dev gcc-11-multilib
+          - name: jammy-py310-clang14
+            host: ubuntu-22.04
+            packages: python3 python3-distutils python3.10-dev clang-14
+            preinstall: |
+              sudo rm -f /usr/bin/x86_64-linux-gnu-gcc
+              sudo ln -s /usr/bin/clang-14 /usr/bin/x86_64-linux-gnu-gcc
+    runs-on: ${{ matrix.host }}
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install ${{ matrix.packages }}
+      - name: Prepare environment
+        if: ${{ matrix.preinstall }}
+        run: ${{ matrix.preinstall }}
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build wrapper
+        run: |
+          python3 setup.py install --user
+      - name: Test wrapper
+        run: |
+          python3 test.py

--- a/test.py
+++ b/test.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2022 Free Software Foundation, Inc. <http://fsf.org/>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import ltc_scrypt
+
+INPUT = [
+    "020000004c1271c211717198227392b029a64a7971931d351b387bb80db027f270411e398a07046f7d4a08dd815412a8712f874a7ebf0507e3878bd24e20a3b73fd750a667d2f451eac7471b00de6659",
+    "0200000011503ee6a855e900c00cfdd98f5f55fffeaee9b6bf55bea9b852d9de2ce35828e204eef76acfd36949ae56d1fbe81c1ac9c0209e6331ad56414f9072506a77f8c6faf551eac7471b00389d01",
+    "02000000a72c8a177f523946f42f22c3e86b8023221b4105e8007e59e81f6beb013e29aaf635295cb9ac966213fb56e046dc71df5b3f7f67ceaeab24038e743f883aff1aaafaf551eac7471b0166249b",
+    "010000007824bc3a8a1b4628485eee3024abd8626721f7f870f8ad4d2f33a27155167f6a4009d1285049603888fe85a84b6c803a53305a8d497965a5e896e1a00568359589faf551eac7471b0065434e",
+    "0200000050bfd4e4a307a8cb6ef4aef69abc5c0f2d579648bd80d7733e1ccc3fbc90ed664a7f74006cb11bde87785f229ecd366c2d4e44432832580e0608c579e4cb76f383f7f551eac7471b00c36982"
+]
+
+EXPECTED = [
+    "00000000002bef4107f882f6115e0b01f348d21195dacd3582aa2dabd7985806",
+    "00000000003a0d11bdd5eb634e08b7feddcfbbf228ed35d250daf19f1c88fc94",
+    "00000000000b40f895f288e13244728a6c2d9d59d8aff29c65f8dd5114a8ca81",
+    "00000000003007005891cd4923031e99d8e8d72f6e8e7edc6a86181897e105fe",
+    "000000000018f0b426a4afc7130ccb47fa02af730d345b4fe7c7724d3800ec8c"
+]
+
+def check_scrypt(input, expected):
+    output = ltc_scrypt.getPoWHash(input)
+    assert expected == output, f"expected {expected}, got {output}"
+
+def run_test():
+    if len(INPUT) != len(EXPECTED):
+        raise Exception("INPUT and EXPECTED arrays have different lengths, aborting.")
+
+    for i in range(len(INPUT)):
+        check_scrypt(bytes.fromhex(INPUT[i]), bytes.fromhex(EXPECTED[i])[::-1])
+
+    print("test successful.")
+
+if __name__ == '__main__':
+    run_test()


### PR DESCRIPTION
Creates a test script and a CI that executes the test on 4 x86_64 configurations:

1. Bionic / Python 3.6 / gcc 7 - because that's used in the dogecoin/dogecoin CI
2. Focal / Python 3.8 / gcc 9 - because that's the stable old-lts
3. Jammy / Python 3.10 / gcc 11 - because that's the current lts
4. Jammy / Python 3.10 / clang 14 - to also test clang

Notes:

1. I ran into issues using `CC=clang-14` with the build step, because for some reason python3-distutils is still calling `x86_64-linux-gnu-gcc` in the module compilation step. I have for now worked around this by linking `/usr/bin/clang-14` as `/usr/bin/x86_64-linux-gnu-gcc`, but this is ugly and should eventually be removed.
2. The test fixtures were taken from [the scrypt unit tests in dogecoin/dogecoin](https://github.com/dogecoin/dogecoin/blob/3a29ba6d497cd1d0a32ecb039da0d35ea43c9c85/src/test/scrypt_tests.cpp#L14-L15) which are the same as the ones used by Litecoin.