### PR TITLE
move version to 1.0.99

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,6 @@ ltc_scrypt_module = Extension('ltc_scrypt',
                                include_dirs=['.'])
 
 setup (name = 'ltc_scrypt',
-       version = '1.0.1',
+       version = '1.0.99',
        description = 'Bindings for scrypt proof of work used by Litecoin',
        ext_modules = [ltc_scrypt_module])


### PR DESCRIPTION
Using .99 as the default version suffix on the main branch allows us to distinguish work in progress from actual releases.

Next release can tag either 1.0.2, or 1.1.0, depending on what changes we publish, independent from what the main branch version is.